### PR TITLE
add famo.us and rename category "Frameworks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A collection of awesome browser-side  JavaScript libraries, resources and shiny 
 * [buddy.js](https://github.com/danielstjules/buddy.js) - Magic number detection for JavaScript.
 
 
-## MVC Frameworks
+## (MVC) Frameworks and Libraries
 
 * [angular.js](https://github.com/angular/angular.js) - HTML enhanced for web apps.
 * [backbone](https://github.com/jashkenas/backbone) - Give your JS App some Backbone with Models, Views, Collections, and Events.
@@ -131,7 +131,7 @@ A collection of awesome browser-side  JavaScript libraries, resources and shiny 
 * [thorax](https://github.com/walmartlabs/thorax) - Strengthening your Backbone.
 * [chaplin](https://github.com/chaplinjs/chaplin) - An architecture for JavaScript applications using the Backbone.js library.
 * [marionette](https://github.com/marionettejs/backbone.marionette) - A composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.
-
+* [famo.us](http://famo.us/) - A free, open source JavaScript framework that helps you create smooth, complex UIs for any screen.
 
 ## Templating Engines
 *Templating engines allow you to perform string interpolation.*


### PR DESCRIPTION
Renamed MVC "frameworks" into "(MVC) Frameworks and Libraries" because of the following reasons:
- famo.us is definitely worth including, but it is not a **MVC** framework
- Backbone is **not** a framework

From [backbonejs.org](http://backbonejs.org/):

> Backbone is a library, not a framework, and plays well with others. You can embed Backbone widgets in Dojo apps without trouble, or use Backbone models as the data backing for D3 visualizations (to pick two entirely random examples).
- React is **not** a MVC framework

From [facebook.github.io/react](http://facebook.github.io/react/):

> Lots of people use React as the V in MVC.
