### PR TITLE
remove yepnope

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ A collection of awesome browser-side  JavaScript libraries, resources and shiny 
 * [lazyload](https://github.com/rgrove/lazyload/) - Tiny, dependency-free async JavaScript and CSS loader.
 * [script.js](https://github.com/ded/script.js) - Asyncronous JavaScript loader and dependency manager.
 * [systemjs](https://github.com/systemjs/systemjs) - AMD, CJS & ES6 spec-compliant module loader.
-* [yepnope.js](https://github.com/SlexAxton/yepnope.js) - An Asynchronous Conditional Resource Loader.
 * [webpack](https://github.com/webpack/webpack) - Module loader made for big projects. Supports AMD, CommonJS, and more.
 
 


### PR DESCRIPTION
yepnope.js is deprecated and only around for archival purposes anymore. I'd say that's a good reason to remove it.

> Yepnope has been deprecated. There are new best practices that you should likely follow instead. Please read our notice here. We will keep these docs online for those still using the old version.
