### PR TITLE
Add `babelfish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ There're also some great commercial libraries, like [amchart](http://www.amchart
 
 * [i18next](https://github.com/jamuhl/i18next) - internationalisation (i18n) with javascript the easy way.
 * [polyglot](https://github.com/airbnb/polyglot.js) - tiny i18n helper library.
+* [babelfish](https://github.com/nodeca/babelfish/) - i18n with human friendly API and built in plurals support.
 
 ## Class
 


### PR DESCRIPTION
[babelfish](https://github.com/nodeca/babelfish/)

In 99% of cases "advanced" i18n people just need plurals. Babelfish provides simple notation to support plurals directly in phrases, with zero coding.