### PR TITLE
Add ObjectEventTarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ There're also some great commercial libraries, like [amchart](http://www.amchart
 * [contra](https://github.com/bevacqua/contra/) - Asynchronous flow control with a functional taste to it.
 * [Bluebird](https://github.com/petkaantonov/bluebird/) - fully featured promise library with focus on innovative features and performance.
 * [when](https://github.com/cujojs/when) - A solid, fast Promises/A+ and when() implementation, plus other async goodies.
+* [ObjectEventTarget](https://github.com/gartz/ObjectEventTarget) - Provide a prototype that add support to event listeners (with same behavior of EventTarget from DOMElements available on browsers).
 
 
 ## Routing


### PR DESCRIPTION
https://github.com/gartz/ObjectEventTarget

It worths because you can set it as prototype of constructor function and all instances will be able to listen for events you can dispatch from inside your object logic, just like you work with DOMElements, what is very well documented and reliable. And you don't need to create any special property in your object it works detecting the context of the object, and easy allow to that object be extended and still work.

Test coverage 99% and documented.