### PR TITLE
This version of Famous is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
   * [Testing Frameworks](#testing-frameworks)
   * [QA Tools](#qa-tools)
   * [MVC Frameworks and Libraries](#mvc-frameworks-and-libraries)
-  * [Non-MVC Frameworks](#non-mvc-frameworks)
   * [Node-Powered CMS Frameworks](#node-powered-cms-frameworks)
   * [Templating Engines](#templating-engines)
   * [Data Visualization](#data-visualization)

--- a/README.md
+++ b/README.md
@@ -177,11 +177,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [LiquidLava](http://www.lava-framework.com/) - Transparent MVC framework for building user interfaces.
 
 
-## Non-MVC Frameworks
-
-* [famous](https://github.com/Famous/famous) - A JavaScript framework for everyone who wants to build beautiful experiences on any device.
-
-
 ## Templating Engines
 *Templating engines allow you to perform string interpolation.*
 


### PR DESCRIPTION
Instead of it there is new one Famous, and it is differ from an old famous:

https://github.com/famous/engine
https://github.com/Famous/framework (alpha)