### PR TITLE
Add diff2html to Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ There're also some great commercial libraries, like [amchart](http://www.amchart
 
 * [Papa Parse](https://github.com/mholt/PapaParse) - A powerful CSV library that supports parsing CSV files/strings and also exporting to CSV.
 * [jBinary](https://github.com/jDataView/jBinary) - High-level I/O (loading, parsing, manipulating, serializing, saving) for binary files with declarative syntax for describing file types and data structures.
+* [diff2html](https://github.com/rtfpessoa/diff2html) - Git diff output parser and pretty HTML generator.
 
 
 ## Functional Programming


### PR DESCRIPTION
[diff2html](https://github.com/rtfpessoa/diff2html) is an simple parsing library for git diffs that creates a JSON representation of the diff and can also generate pretty HTML.