### PR TITLE
Add package just-handlebars-helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ http://www.listjs.com
 * [mixitup](https://github.com/patrickkunka/mixitup) - MixItUp - A Filter & Sort Plugin
 * [grid](https://github.com/uberVU/grid) - Drag and drop library for two-dimensional, resizable and responsive lists.
 * [jquery-match-height](https://github.com/liabru/jquery-match-height) - a responsive equal heights plugin for jQuery.
+* [just-handlebars-helpers](https://github.com/leapfrogtechnology/just-handlebars-helpers) A lightweight package with common Handlebars helpers.
 
 ## Podcasts
 * [JavaScript Air](http://javascriptair.com) - The live video broadcast podcast all about JavaScript and the Web platform.


### PR DESCRIPTION
[just-handlebars-helpers](https://www.npmjs.com/package/just-handlebars-helpers) is a fully-tested, modern lightweight package with common helpers for [handlebars](https://github.com/wycats/handlebars.js) templating engine. It's available for both node & browser. 

See more: https://github.com/leapfrogtechnology/just-handlebars-helpers#just-handlebars-helpers.
