### PR TITLE
Add Lazy Progressive Enhancement to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ http://www.listjs.com
 * [mixitup](https://github.com/patrickkunka/mixitup) - MixItUp - A Filter & Sort Plugin
 * [grid](https://github.com/uberVU/grid) - Drag and drop library for two-dimensional, resizable and responsive lists.
 * [jquery-match-height](https://github.com/liabru/jquery-match-height) - a responsive equal heights plugin for jQuery.
+* [Lazy Progressive Enhancement](http://tylerdeitz.co/lazy-progressive-enhancement/) - A lazy image loader designed to enforce progressive enhancement and valid HTML.
 
 ## Podcasts
 * [JavaScript Air](http://javascriptair.com) - The live video broadcast podcast all about JavaScript and the Web platform.


### PR DESCRIPTION
[Lazy Progressive Enhancement](http://tylerdeitz.co/lazy-progressive-enhancement/) is an image loader that is structurally designed to fall back to a standard loading behavior for users without javascript. This means that web developers don't have to include additional fallbacks to gracefully degrade images, because the markup itself provides this. 

I built this because I wanted to use a lazy image library that would actually pass an HTML5 validator. Omitting an image's src attribute, like most lazy loaders do to defer loading, is [invalid HTML](https://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src). Getting around that by setting the src to a byte-sized placeholder adds a lot of markup complexity and is pretty ugly. Either way, the standard lazy loading methods available now completely fail for users without javascript.

-
[Project website](http://tylerdeitz.co/lazy-progressive-enhancement/), [Github repository](https://github.com/tvler/lazy-progressive-enhancement/)