### PR TITLE
Update unsupported BootstrapValidator link to point to renamed FormValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Besides libraries, there're [Collection on Codepen](http://codepen.io/collection
 * [validator.js](https://github.com/chriso/validator.js) - String validation and sanitization.
 * [validate.js](https://github.com/rickharrison/validate.js) - Lightweight JavaScript form validation library inspired by CodeIgniter.
 * [validatr](https://github.com/jaymorrow/validatr/) - Cross Browser HTML5 Form Validation.
-* [BootstrapValidator](https://github.com/nghuuphuoc/bootstrapvalidator) - The best jQuery plugin to validate form fields. Designed to use with Bootstrap 3.
+* [FormValidation](http://formvalidation.io/) - The best jQuery plugin to validate form fields. Formerly BootstrapValidator.
 * [is.js](https://github.com/arasatasaygin/is.js) -  Check types, regexps, presence, time and more.
 * [FieldVal](https://github.com/FieldVal/fieldval-js) - multipurpose validation library. Supports both sync and async validation.
 


### PR DESCRIPTION
A message on the [BootstrapValidator README](https://github.com/nghuuphuoc/bootstrapvalidator/blob/master/README.md) says that the project is no longer supported.  The project is now maintained under the name FormValidation.