### PR TITLE
Remove batman.js (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [angular.js](https://github.com/angular/angular.js) - HTML enhanced for web apps.
 * [aurelia](http://aurelia.io) - A Javascript client framework for mobile, desktop and web.
 * [backbone](https://github.com/jashkenas/backbone) - Give your JS App some Backbone with Models, Views, Collections, and Events.
-* [batman.js](http://batmanjs.org/) - The best JavaScript framework for Rails developers.
 * [ember.js](https://github.com/emberjs/ember.js) - A JavaScript framework for creating ambitious web applications.
 * [meteor](https://github.com/meteor/meteor) - An ultra-simple, database-everywhere, data-on-the-wire, pure-Javascript web framework.
 * [ractive](https://github.com/ractivejs/ractive) - Next-generation DOM manipulation.


### PR DESCRIPTION
batman.js has been deprecated since 2014 and is no longer maintained, as explain here https://engineering.shopify.com/blogs/engineering/rebuilding-the-shopify-admin-improving-developer-productivity-by-deleting-28-000-lines-of-javascript