### PR TITLE
[pykcharts.js](https://github.com/pykih/PykCharts.js) - Removes obsolete library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 
 * [d3](https://github.com/d3/d3) - A JavaScript visualization library for HTML and SVG.
   * [metrics-graphics](https://github.com/mozilla/metrics-graphics) - A library optimized for concise, principled data graphics and layouts.
-* [pykcharts.js](https://github.com/pykih/PykCharts.js) - Well designed d3.js charting without the complexity of d3.js.
 * [three.js](https://github.com/mrdoob/three.js) - JavaScript 3D library.
 * [Chart.js](https://github.com/chartjs/Chart.js) - Simple HTML5 Charts using the <canvas> tag.
 * [paper.js](https://github.com/paperjs/paper.js) - The Swiss Army Knife of Vector Graphics Scripting – Scriptographer ported to JavaScript and the browser, using HTML5 Canvas.


### PR DESCRIPTION
 Removes the obsolete pykcharts.js library from the list