### PR TITLE
Add mithril-slides under sliders section

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ Besides libraries, there're [Collection on Codepen](http://codepen.io/collection
 * [Flickity](https://github.com/metafizzy/flickity) - Touch, responsive, flickable galleries.
 * [Glide.js](https://github.com/jedrzejchalubek/glidejs) - Responsive and touch-friendly jQuery slider. It's simple, lightweight and fast.
 * [jQuery.adaptive-slider](https://github.com/creative-punch/jQuery.adaptive-slider/) - A jQuery plugin for a slider with adaptive colored figcaption and navigation.
+* [mithril-slides](https://github.com/wulab/mithril-slides) - A Keynote-inspired presentation app written with Mithril.
 
 ## Range Sliders
 


### PR DESCRIPTION
Please let me add my little project, [mithril-slides][1], which could be handy for a developer who wants to quickly create slides to present his ideas or projects. Thanks!

![screenshots](https://cloud.githubusercontent.com/assets/592709/17454537/012dc70c-5bc4-11e6-86e1-5d5ce2bc35b8.gif)

[1]: https://github.com/wulab/mithril-slides