### PR TITLE
Create separate 'Mocking' category under Testing, and add Mockttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 ### Mocking
 
 * [Sinon.JS](https://github.com/sinonjs/sinon) - Test spies, stubs, and mocks for JavaScript.
+* [Mockttp](https://github.com/pimterry/mockttp) - HTTP/HTTPS stubbing & mocking tool for integration testing.
 
 ### Coverage
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 
 * [chai](https://github.com/chaijs/chai) - BDD / TDD assertion framework for node.js and the browser that can be paired with any testing framework.
 * [Enzyme](http://airbnb.io/enzyme/index.html) - Enzyme is a JavaScript Testing utility for React that makes it easier to assert, manipulate, and traverse your React Components' output.
-* [Sinon.JS](https://github.com/sinonjs/sinon) - Test spies, stubs, and mocks for JavaScript.
 * [expect.js](https://github.com/Automattic/expect.js) - Minimalistic BDD-style assertions for Node.JS and the browser.
+
+### Mocking
+
+* [Sinon.JS](https://github.com/sinonjs/sinon) - Test spies, stubs, and mocks for JavaScript.
 
 ### Coverage
 


### PR DESCRIPTION
Sinon is not really an assertion framework - it's a mocking tool - so I've pulled that into a separate subcategory for mocking tools, and added Mockttp too (an HTTP server mocking tool).