### PR TITLE
Update devdocs.io from HTTP -> HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 
 ## Documentation
 
-* [DevDocs](http://devdocs.io/) is an all-in-one API documentation reader with a fast, organized, and consistent interface.
+* [DevDocs](https://devdocs.io/) is an all-in-one API documentation reader with a fast, organized, and consistent interface.
 * [dexy](http://www.dexy.it/) is a free-form literate documentation tool for writing any kind of technical document incorporating code.
 * [docco](http://jashkenas.github.io/docco/) is a quick-and-dirty, hundred-line-long, literate-programming-style documentation generator.
 * [styledocco](http://jacobrask.github.io/styledocco/) generates documentation and style guide documents from your stylesheets.


### PR DESCRIPTION
A visit to http://devdocs.io displays the warning “DevDocs is migrating to HTTPS. Please update your bookmarks to point to https://devdocs.io.”