### PR TITLE
Add machine learning links

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,8 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Brain.js](https://github.com/harthur/brain) - Neural networks in JavaScript.
 * [Mind.js](https://github.com/stevenmiller888/mind) - A flexible neural network library.
 * [Synaptic.js](https://github.com/cazala/synaptic) - Architecture-free neural network library for node.js and the browser.
-* [deeplearn.js](https://deeplearnjs.org/) - A hardware-accelerated machine intelligence library for the web.
+* [TensorFlow.js](https://js.tensorflow.org) - A JavaScript library for training and deploying ML models in the browser and on Node.js.
+* [ml5.js](https://ml5js.org) - Friendly Machine Learning for the Web.
 
 
 ## Browser Detection


### PR DESCRIPTION
Hello,

I was checking some links in the machine learning section and noticed the deeplearn.js library.
But deeplearn.js became part of Tensorflow ecosystem and changed its name to tensorflow.js.

So I'm making the pull request to update this library and also add a new machine learning library.