### PR TITLE
Removed 'standard'

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [buddy.js](https://github.com/danielstjules/buddy.js) - Magic number detection for JavaScript.
 * [ESLint](https://github.com/eslint/eslint) - A fully pluggable tool for identifying and reporting on patterns in JavaScript.
 * [JSLint](https://github.com/douglascrockford/JSLint) - High-standards, strict & opinionated code quality tool, aiming to keep only good parts of the language.
-* [JavaScript Standard Style](https://github.com/feross/standard) - Opinionated, no-configuration style guide, style checker, and formatter
 
 
 ## MVC Frameworks and Libraries


### PR DESCRIPTION
I'm removing this, because it doesn't belong in the list. The [package](https://github.com/standard/standard) is nothing more but an ESLint config, misleadingly named as "Standard", even though it's not a standard by any stretch.

Furthermore, the maintainer of this package has retroactively tried to extract value from users, by inserting terminal ads into the package's postinstall scripts, although they were removed shortly after, for violating NPM's ToC, as well as stirring a lot of controversy amongst the F/LOSS community.