### PR TITLE
Added new QA topic with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [ESLint](https://github.com/eslint/eslint) - A fully pluggable tool for identifying and reporting on patterns in JavaScript.
 * [JSLint](https://github.com/douglascrockford/JSLint) - High-standards, strict & opinionated code quality tool, aiming to keep only good parts of the language.
 * [JavaScript Standard Style](https://github.com/feross/standard) - Opinionated, no-configuration style guide, style checker, and formatter
-
+* [Pre-evaluate code at buildtime](https://github.com/kentcdodds/preval.macro) - Pre-evaluate your front end javascript code at build-time
 
 ## MVC Frameworks and Libraries
 


### PR DESCRIPTION
Added a new topic called Pre-evaluate code at build time plugin with the link to the actual repository which is really cool to use node js code in any front end library or framework without using a node layer.