### PR TITLE
add exifr

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Besides libraries, there're [Collection on Codepen](http://codepen.io/collection
  * [Ion.Sound](https://github.com/IonDen/ion.sound) - Simple sounds on any web page.
  * [photobooth-js](https://github.com/WolframHempel/photobooth-js) - A widget that allows users to take their avatar pictures on your site.
  * [clappr](https://github.com/clappr/clappr) - An extensible media player for the web http://clappr.io
+ * [exifr](https://github.com/MikeKovarik/exifr) - The fastest and most versatile EXIF reading library. https://mutiny.cz/exifr/
 
 ## Typography
 


### PR DESCRIPTION
Hello,
I would like to add my library [exifr](https://github.com/MikeKovarik/exifr) for reading exif metada from photos. It is heavily optimized for speed and memory efficiency. As far as I know and tested it does support the widest array of file formats (jpg, tif, heic), metadata formats (exif/tiff, xmp, icc, iptc, jfif) and is the most performant out of any other JS EXIF libraries.

website & playground: [http://mutiny.cz/exifr/](http://mutiny.cz/exifr/)