### PR TITLE
Add Fetch API wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 
 ## API
 
+* [FarFetch](https://github.com/WebsiteBeaver/far-fetch) - Modern Fetch API wrapper for simplicity.
 * [axios](https://github.com/axios/axios) - Promise based HTTP client for the browser and node.js.
 * [bottleneck](https://github.com/SGrondin/bottleneck) - A powerful rate limiter that makes throttling easy.
 * [oauth-signature-js](https://github.com/bettiolo/oauth-signature-js) - JavaScript OAuth 1.0a signature generator for node and the browser.

--- a/README.md
+++ b/README.md
@@ -534,7 +534,6 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 
 ## API
 
-* [FarFetch](https://github.com/WebsiteBeaver/far-fetch) - Modern Fetch API wrapper for simplicity.
 * [axios](https://github.com/axios/axios) - Promise based HTTP client for the browser and node.js.
 * [bottleneck](https://github.com/SGrondin/bottleneck) - A powerful rate limiter that makes throttling easy.
 * [oauth-signature-js](https://github.com/bettiolo/oauth-signature-js) - JavaScript OAuth 1.0a signature generator for node and the browser.
@@ -543,6 +542,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Rails Ranger](https://github.com/victor-am/rails-ranger) - An opinionated REST client for Ruby on Rails APIs.
 * [wretch](https://github.com/elbywan/wretch) - A tiny wrapper built around fetch with an intuitive syntax.
 * [Bearer.sh](https://github.com/Bearer/bearer-js) - Universal API client that supports OAuth / API Key / Basic / etc.
+* [FarFetch](https://github.com/WebsiteBeaver/far-fetch) - Modern Fetch API wrapper for simplicity, with concise file uploading.
 
 ## Streaming
 


### PR DESCRIPTION
I believe this wrapper has several advantages over some of the classes listed.

- Concise file uploading.
- Its philosophy is to improve `Fetch API`, rather than create a new opinionated wrapper. It tries to stay as close as possible to vanilla fetch, fix inconsistencies and make code more modern and readable.
- Has a unified `data` property on request that automatically does the correct type for `GET` (params) and `POST` (body) behind the scenes.