### PR TITLE
Add Optic to List

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [wretch](https://github.com/elbywan/wretch) - A tiny wrapper built around fetch with an intuitive syntax.
 * [Bearer.sh](https://github.com/Bearer/bearer-js) - Universal API client that supports OAuth / API Key / Basic / etc.
 * [FarFetch](https://github.com/WebsiteBeaver/far-fetch) - Modern Fetch API wrapper for simplicity, with concise file uploading.
+* [Optic](https://github.com/opticdev/optic) - Optic automatically documents and tests your APIs
 
 ## Streaming
 


### PR DESCRIPTION
Optic automatically documents and tests your APIs.

I think Optic is awesome because its super simple to use and lets you easily add docs to any project. For most api projects, maintaining and creating documentation is a pain, and optic greatly streamlines this process.

[Repo: opticdev/optic](https://github.com/opticdev/optic), [Homepage: useoptic.com](https://useoptic.com)