### PR TITLE
fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [EJS](https://github.com/mde/ejs) - Effective JavaScript templating.
 * [xtemplate](https://github.com/xtemplate/xtemplate) - eXtensible Template Engine lib for node and the browser
 * [marko](https://github.com/marko-js/marko) - A fast, lightweight, HTML-based templating engine for Node.js and the browser with async, streaming, custom tags and CommonJS modules as compiled output.
-* [swig](http://paularmstrong.github.io/swig/) - A simple, powerful, and extendable Node.js and browser-based JavaScript template engine.
+* [swig](https://github.com/paularmstrong/swig) - (Archived) A simple, powerful, and extendable Node.js and browser-based JavaScript template engine.
 * [EHTML](https://github.com/Guseyn/EHTML) - HTML Framework that allows you not to write JavaScript code.
 
 ## Articles and Posts


### PR DESCRIPTION
[swig](https://github.com/paularmstrong/swig) has been achived and the github page turned 404. It needs to be refered a github repository for who stilll need this. 
 