### PR TITLE
Add Fluent to l10n libraries/frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [i18next](https://github.com/i18next/i18next) - internationalisation (i18n) with javascript the easy way.
 * [polyglot](https://github.com/airbnb/polyglot.js) - tiny i18n helper library.
 * [babelfish](https://github.com/nodeca/babelfish/) - i18n with human friendly API and built in plurals support.
+* [Fluent](https://projectfluent.org/) - Powerful l10n system with DSL for natural-sounding translations.
 
 ## Control Flow
 


### PR DESCRIPTION
Site: https://projectfluent.org/

It's a *very* powerful internationalization + localization framework (dual-purpose) backed by Mozilla that features a DSL for simplified, scalable translations. There's a [Mozilla Hacks blog post](https://hacks.mozilla.org/2019/04/fluent-1-0-a-localization-system-for-natural-sounding-translations/) explaining much of it.

Re-filed from #616 (closed due to age)