### PR TITLE
Add Rambda to functional programming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [mout](https://github.com/mout/mout) - Modular JavaScript Utilities.
 * [mesh](https://github.com/crcn/mesh.js) - Streamable data synchronization utility.
 * [preludejs](https://github.com/alanrsoares/prelude-js) - Hardcore Functional Programming for JavaScript.
+* [rambda](https://github.com/selfrefactor/rambda) - Faster and smaller alternative to *Ramda*.
 
 
 ## Reactive Programming


### PR DESCRIPTION
I know that `Ramda` is already part of the list, so I will accept if you consider the inclusion of `Rambda` to be confusing to your visitors.