### PR TITLE
Add a link to awesome-typescript list

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 
 ## Type Checkers
 
-* [TypeScript](https://www.typescriptlang.org/) - A typed superset of JavaScript that compiles to plain JavaScript.
+* [TypeScript](https://github.com/vstan02/awesome-typescript) - A typed superset of JavaScript that compiles to plain JavaScript.
 * [Flow.js](https://flow.org/en/) - A static type checker for JavaScript from Facebook.
 * [Hegel](https://jsmonk.github.io/hegel/) -  A static type checker for JavaScript with a bias on type inference an strong type system.
 * [TypL](https://github.com/getify/TypL) - the JavaScript Type Linter with a bias on type inference.


### PR DESCRIPTION
Update TypeScript (from Type Checkers category) to link to awesome-typescript list