### PR TITLE
add bundle.js.org to bundlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Microbundle](https://github.com/developit/microbundle) - Zero-configuration bundler for tiny modules.
 * [FuseBox](https://github.com/fuse-box/fuse-box) - A bundler that does it right
 * [Snowpack](https://www.snowpack.dev/) - A lightning-fast frontend build tool, designed for the modern web.
+* [bundle](https://bundle.js.org) - A quick online npm package size checker.
 
 
 ## Type Checkers


### PR DESCRIPTION
<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there ~~for a while~~, and actively maintained.
- [ ] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->

**bundle** is an online tool to quickly and easily bundle your projects and see the minified and gzipped size, it's similar to bundlephobia but does all the work locally on your computer and can treeshake multiple packages (both commonjs and esm) into a bundle, it does all this via esbuild-wasm and rollup. I belive other people will benefit from it, so I am posting it here.

The repo is located here https://github.com/okikio/bundle