### PR TITLE
Updated the link to ramda

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [lodash](https://github.com/lodash/lodash) - A utility library delivering consistency, customization, performance, & extras.
 * [Sugar](https://github.com/andrewplummer/Sugar) - A JavaScript library for working with native objects.
 * [lazy.js](https://github.com/dtao/lazy.js) - Like Underscore, but lazier.
-* [ramda](https://github.com/CrossEye/ramda) - A practical functional library for JavaScript programmers.
+* [ramda](https://github.com/ramda/ramda) - A practical functional library for JavaScript programmers.
 * [mout](https://github.com/mout/mout) - Modular JavaScript Utilities.
 * [preludejs](https://github.com/alanrsoares/prelude-js) - Hardcore Functional Programming for JavaScript.
 * [rambda](https://github.com/selfrefactor/rambda) - Faster and smaller alternative to *Ramda*.


### PR DESCRIPTION
<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [ ] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->

The link to the `ramda` library was pointed to a fork of the original repository. The same has been updated with the proper link.

Old: [ramda](https://github.com/CrossEye/ramda)
New: [ramda](https://github.com/ramda/ramda)
