### PR TITLE
Added link of JavaScript Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
   * [SDK](#sdk)
   * [Misc](#misc)
   * [Podcasts](#podcasts)
+
 * [Worth Reading](#worth-reading)
 * [Other Awesome Lists](#other-awesome-lists)
+* [Roadmaps](#roadmaps)
 * [Contributing](#contributing)
 
 ----
@@ -1100,9 +1102,14 @@ https://listjs.com
 * [denolib/awesome-deno](https://github.com/denolib/awesome-deno)
 * [apvarun/awesome-bun](https://github.com/apvarun/awesome-bun)
 
+# Roadmap
+
+* [JavaScript Roadmap](https://roadmap.sh/javascript)
+
 # Contributing
 
 Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first.
+
 
 # License
 


### PR DESCRIPTION
Hi chencheng,

I came across your repository [awesome-javascript](https://github.com/sorrycc/awesome-javascript) and found it to be a valuable resource for JavaScript enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["JavaScript Roadmap"](https://roadmap.sh/javascript). I took the initiative to submit a ["Pull Request"](https://github.com/sorrycc/awesome-javascript/pull/848) adding it in a separate roadmap section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz
