### PR TITLE
docs(assertion): add Supertest JavaScript assertion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Sinon.JS](https://github.com/sinonjs/sinon) - Test spies, stubs, and mocks for JavaScript.
 * [expect.js](https://github.com/Automattic/expect.js) - Minimalistic BDD-style assertions for Node.JS and the browser.
 * [proxyquire](https://github.com/thlorenz/proxyquire) - Stub nodejs's require.
+* [Supertest](https://github.com/visionmedia/supertest) - A popular HTTP assertion library for testing REST APIs, often used with other testing frameworks like Mocha or Jest
 
 ### Coverage
 


### PR DESCRIPTION
`Supertest` is a popular HTTP assertion library for testing REST APIs, often used with other testing frameworks like Mocha or Jest

<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->

...
