### PR TITLE
docs(readme): add Vite link to bundlers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 
 ## Bundlers
 
-* [Vite](https://vite.dev/) - Next Generation Frontend Tooling.
 * [webpack](https://github.com/webpack/webpack) - Packs CommonJs/AMD modules for the browser.
 * [Rollup](https://github.com/rollup/rollup) - Next-generation ES6 module bundler.
 * [Brunch](https://github.com/brunch/brunch) - Fast front-end web app build tool with simple declarative config.
@@ -133,6 +132,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [FuseBox](https://github.com/fuse-box/fuse-box) - A bundler that does it right
 * [Snowpack](https://www.snowpack.dev/) - A lightning-fast frontend build tool, designed for the modern web.
 * [bundle](https://bundle.js.org) - A quick online npm package size checker.
+* [Vite](https://vite.dev/) - Next Generation Frontend Tooling.
 
 # Minimizers
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 
 ## Bundlers
 
+* [Vite](https://vite.dev/) - Next Generation Frontend Tooling.
 * [webpack](https://github.com/webpack/webpack) - Packs CommonJs/AMD modules for the browser.
 * [Rollup](https://github.com/rollup/rollup) - Next-generation ES6 module bundler.
 * [Brunch](https://github.com/brunch/brunch) - Fast front-end web app build tool with simple declarative config.


### PR DESCRIPTION
Added a link to Vite in the bundlers section of the README. Vite is a next-generation frontend tooling optimized for speed and modern development workflows.

<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->

...
