### PR TITLE
Add pdf-encrypt-lite to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [xss-filters](https://github.com/yahoo/xss-filters) - Secure XSS Filters by Yahoo.
 * [sanitize-html](https://github.com/apostrophecms/sanitize-html) - sanitize-html provides a simple HTML sanitizer with a clear API.
 * [pompelmi](https://github.com/pompelmi/pompelmi) - Fast file-upload malware scanning for Node.js.
+* [pdf-encrypt-lite](https://github.com/smither777/pdfsmaller-pdfencryptlite) - Ultra-lightweight (7KB) PDF encryption with RC4 128-bit. Works in browsers and edge runtimes.
+
 
 ## Log
 


### PR DESCRIPTION
<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [X] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [X] I've added the new resource at the end of its section.
- [X] This resource is out there for a while, and actively maintained.
- [X] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->
Adding [pdf-encrypt-lite](https://github.com/smither777/pdfsmaller-pdfencryptlite) - an ultra-lightweight (7KB) PDF encryption library.

- Real RC4 128-bit encryption per PDF specification
- Works in browsers, Node.js, and edge runtimes (Cloudflare Workers, Vercel Edge)
- Zero dependencies (only pdf-lib as peer dependency)
- Battle-tested on [PDFSmaller.com](https://pdfsmaller.com)

npm: https://www.npmjs.com/package/@pdfsmaller/pdf-encrypt-lite
...
