### PR TITLE
Add Online Compilers section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,11 @@ https://listjs.com
 * [lune](https://github.com/ryanseys/lune) - Library to calculate the phases of the moon accurately.
 * [jsemu](https://github.com/fcambus/jsemu) - A list of emulators written in the JavaScript programming language.
 
+## Online Compilers
+
+* [PlayCode](https://playcode.io/javascript-compiler) - JavaScript compiler with TypeScript/JSX compilation, AI coding assistant, npm packages, and real-time execution. Used by 1M+ developers.
+
+
 # Worth Reading
  
 * [You Don't Know JS](https://github.com/getify/You-Dont-Know-JS) - Possibly the best book written on modern JavaScript, completely readable online for free, or can be bought to support the author.


### PR DESCRIPTION
## Added new "Online Compilers" section with PlayCode

**What this adds:**

A new "Online Compilers" section for browser-based JavaScript compilation tools, starting with PlayCode.

**Why a new section:**

The repository covers transpilers, bundlers, and minimizers (build-time tools), but lacks a category for online JavaScript compilers/runners - tools developers use daily for quick prototyping, testing, and learning. This fills that gap.

**About PlayCode:**

[PlayCode](https://playcode.io/javascript-compiler) is an online JavaScript compiler used by over 1 million developers. It features:

- Real-time JavaScript/TypeScript/JSX compilation
- Live preview with instant feedback
- npm package support
- AI coding assistant
- Multi-file project support

**Why it belongs here:**

- Actively maintained since 2017
- 1M+ monthly active users
- Featured tool for JavaScript development and learning
- Runs entirely in the browser (no server-side execution)
- Free to use

This section could also include other popular online compilers in the future (similar to how "Editors" grew over time).