### PR TITLE
docs: add rev-dep to qa tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Pre-evaluate code at buildtime](https://github.com/kentcdodds/preval.macro) - Pre-evaluate your front end javascript code at build-time
 * [JS-Beautifier](https://github.com/beautify-web/js-beautify) - Npm cli and library to format JS code.
 * [husky](https://github.com/typicode/husky) - Prevents bad git commit, git push and more.
+* [Rev-dep](https://github.com/jayu/rev-dep) - Trace imports, identify circular dependencies, find unused code, clean node modules — all from a blazing-fast CLI.
 
 ## MVC Frameworks and Libraries
 


### PR DESCRIPTION
<!-- Thank you for your interest in Awesome JavaScript 🎉 -->

<!-- These comment lines are only here to guide you, and will not be visible in the pull request you're about to create. -->

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

<!-- Please explain what this new addition is about, and why it should be included here with your own words. -->

Hi, I would like to add my tool rev-dep. It's dependency analysis and optimization toolkit for modern JavaScript and TypeScript projects. 

It can be used to trace imports, identify circular dependencies, find unused code, clean node modules.

I've recently reimplemented the tool in Go, which made it very fast, much faster than alternatives. 

It's not yet popular, but I believe lists like this one are one of the ways to make such tool popular and adopted by many. 

