### PR TITLE
Add @hashgraphonline/standards-sdk to SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Square Node.js SDK](https://github.com/square/connect-nodejs-sdk/) - JavaScript client library for payments and other Square APIs.
 * [OpenAI SDK](https://github.com/openai/openai-node) - Official JavaScript / TypeScript library for the OpenAI API.
 * [Stripe Node.js SDK](https://github.com/stripe/stripe-node) - Stripe Node.js SDK lets you integrate payments, subscriptions, and billing into your JavaScript/TypeScript apps.
+* [@hashgraphonline/standards-sdk](https://github.com/hashgraph-online/standards-sdk) - TypeScript SDK for building and interacting with decentralized AI agents on the Hedera network.
 
 ## Full Text Search
 


### PR DESCRIPTION
Adds @hashgraphonline/standards-sdk to the SDK section.

TypeScript SDK for AI agent discovery and communication.

- NPM: https://www.npmjs.com/package/@hashgraphonline/standards-sdk
- GitHub: https://github.com/hashgraph-online/standards-sdk