### PR TITLE
Add react-feedback-surveys to Form Widgets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,8 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [stretchy](https://github.com/LeaVerou/stretchy) - Form element autosizing, the way it should be.
 * [analytics](https://github.com/davidwells/analytics) - A lightweight, extendable analytics library designed to work with any third-party analytics provider to track page views, custom events, & identify users.
 * [dat.GUI](https://github.com/dataarts/dat.gui) - A lightweight gui controller for changing variables in JavaScript.
+* [react-feedback-surveys](https://github.com/feedback-tools-platform/react-feedback-surveys) - Lightweight, zero-dependency survey widgets for collecting user feedback (NPS, CSAT, CES) in React apps.
+
 ## Tips
 
 * [tipsy](https://github.com/jaz303/tipsy) - Facebook-style tooltips plugin for jQuery.


### PR DESCRIPTION
## Summary

Adding [react-feedback-surveys](https://github.com/feedback-tools-platform/react-feedback-surveys) to the Form Widgets > Other section.

**react-feedback-surveys** is a lightweight, zero-dependency library for collecting user feedback in JavaScript/React apps. It provides ready-to-use survey components:

- **NPS (Net Promoter Score)** - 0-10 recommendation scale
- **CSAT (Customer Satisfaction)** - 2 or 5 point scales with emoji/stars/thumbs
- **CES (Customer Effort Score)** - 7-point effort scale

### Key Features
- Zero dependencies
- TypeScript support
- Multiple visual styles (emoji, stars, numbers, thumbs)
- Inline or popup display modes
- Optional follow-up questions
- Fully customizable via CSS variables
- MIT licensed

Thank you for considering this addition!