### PR TITLE
Add odf-kit to Files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 
 * [Papa Parse](https://github.com/mholt/PapaParse) - A powerful CSV library that supports parsing CSV files/strings and also exporting to CSV.
 * [jBinary](https://github.com/jDataView/jBinary) - High-level I/O (loading, parsing, manipulating, serializing, saving) for binary files with declarative syntax for describing file types and data structures.
-* [diff2html](https://github.com/rtfpessoa/diff2html) - Git diff output parser and pretty HTML generator.
+* [odf-kit](https://github.com/GitHubNewbie0/odf-kit) - Generate and fill OpenDocument Format (.odt) files in Node.js and browsers. Zero dependencies, template engine with placeholder support.
+*  [diff2html](https://github.com/rtfpessoa/diff2html) - Git diff output parser and pretty HTML generator.
 * [jsPDF](https://github.com/MrRio/jsPDF) - JavaScript PDF generation.
 * [PDF.js](https://github.com/mozilla/pdf.js) - PDF Reader in JavaScript.
 


### PR DESCRIPTION
odf-kit is a TypeScript library for generating OpenDocument Format (.odt) files programmatically and filling .odt templates with JSON data. It's the only actively maintained JavaScript library for ODF document creation, with zero runtime dependencies, 222 passing tests, and Apache 2.0 licensing. Works in Node.js and browsers. Useful for developers working with governments, non-profits, and organizations that require open document formats.