### PR TITLE
Add MapMetrics GL to Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [jqvmap](https://github.com/manifestinteractive/jqvmap) - jQuery Vector Map Library.
 * [OpenLayers3](https://openlayers.org/) - A high-performance, feature-packed library for all your mapping needs.
 * [H3js](https://github.com/uber/h3) - Hexagonal hierarchical geospatial indexing system ported to javascript by Uber for geospatial visualization.
+* [MapMetrics GL](https://github.com/MapMetrics/mapmetrics-gl) - Mapbox GL JS-compatible mapping library with built-in tiles, geocoding, routing, and search.
 
 ## Video/Audio
 


### PR DESCRIPTION
Adding MapMetrics GL to the Maps section.

MapMetrics GL is a Mapbox GL JS-compatible mapping library with built-in support for map tiles, geocoding, routing, and search. EU-hosted, GDPR compliant.

GitHub: https://github.com/MapMetrics/mapmetrics-gl
Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V.