### PR TITLE
Add pushduck to File Uploader section

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [FileAPI](https://github.com/mailru/FileAPI) - A set of JavaScript tools for working with files. Multiupload, drag'n'drop and chunked file upload. Images: crop, resize and auto orientation by EXIF.
 * [plupload](https://github.com/moxiecode/plupload) - A JavaScript API for dealing with file uploads it supports features like multiple file selection, file type filtering, request chunking, client side image scaling and it uses different runtimes to achieve this such as HTML 5, Silverlight and Flash.
 * [filepond](https://github.com/pqina/filepond) - A JavaScript library that can upload anything you throw at it, optimizes images for faster uploads, and offers a great, accessible, silky smooth user experience.
+* [pushduck](https://github.com/abhay-ramesh/pushduck) - Type-safe S3 file upload library with React hooks, presigned URLs, and support for AWS S3, Cloudflare R2, DigitalOcean Spaces, and MinIO.
 
 ### Other
 


### PR DESCRIPTION
Adding [pushduck](https://github.com/abhay-ramesh/pushduck) to the File Uploader section.

Pushduck is a type-safe S3 file upload library for JavaScript/TypeScript. Unlike traditional uploaders that route files through your server, it uses presigned URLs so files upload directly from the browser to S3-compatible storage (AWS S3, Cloudflare R2, DigitalOcean Spaces, MinIO). Provides React hooks, works on edge runtimes (Cloudflare Workers, Vercel Edge), MIT licensed, 155+ stars.

- GitHub: https://github.com/abhay-ramesh/pushduck
- npm: https://www.npmjs.com/package/pushduck