### PR TITLE
Add Overloop CLI to Generative AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 ## Generative AI
 
 * [KaibanJS](https://github.com/kaiban-ai/KaibanJS) - KaibanJS is an open-source framework browser-compatibility of orchestration of multi-agent ai systems using a Kanban-inspired architecture.
+* [Overloop CLI](https://github.com/sortlist/overloop-cli) - AI-powered outbound engine. Source contacts from 450M+ profiles, run multi-channel campaigns (email + LinkedIn), and manage conversations. JSON output.
 
 ## Misc
 


### PR DESCRIPTION
Adds [Overloop CLI](https://github.com/sortlist/overloop-cli) to the Generative AI section.

Overloop CLI is an AI-powered outbound engine for Node.js. It lets you source contacts from 450M+ profiles, run multi-channel campaigns (email + LinkedIn), enroll prospects, and manage conversations -- all from the terminal with JSON output.

- Install: `npm install -g overloop-cli`
- GitHub: https://github.com/sortlist/overloop-cli
- Website: https://agent.overloop.ai