### PR TITLE
Add Goosekit JSON Formatter to Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [editor](https://github.com/lepture/editor) - A markdown editor. still on development.
 * [EpicEditor](https://github.com/OscarGodson/EpicEditor) - An embeddable JavaScript Markdown editor with split fullscreen editing, live previewing, automatic draft saving, offline support, and more.
 * [jsoneditor](https://github.com/josdejong/jsoneditor) - A web-based tool to view, edit and format JSON.
+* [Goosekit JSON Formatter](https://goosekit.dev/json-formatter/) - Free online JSON formatter, validator and beautifier. Runs 100% in the browser, no signup, no data upload.
 * [vim.js](https://github.com/coolwanglu/vim.js) - JavaScript port of Vim with a persistent `~/.vimrc`.
 * [Squire](https://github.com/neilj/Squire) - HTML5 rich text editor.
 * [TinyMCE](https://github.com/tinymce/tinymce) - The JavaScript Rich Text editor.


### PR DESCRIPTION
Hi! Adding [Goosekit JSON Formatter](https://goosekit.dev/json-formatter/) to the Editors section, right after jsoneditor.

It's a free, browser-based JSON formatter with:
- Format, validate and beautify JSON
- Error highlighting
- Copy to clipboard
- 100% client-side (no data sent to any server)
- No signup required

Thanks for maintaining this awesome list! 🙏