### PR TITLE
Add omni-compress to Image Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [lena.js](https://github.com/davidsonfellipe/lena.js) - A Library for image processing with filters and util functions.
 * [pica](https://github.com/nodeca/pica) - High quality image resize (with fast Lanczos filter, implemented in pure JS).
 * [cropper](https://github.com/fengyuanchen/cropper) - A simple jQuery image cropping plugin.
+* [omni-compress](https://github.com/dharanish-v/omni-compress) - Universal image, audio & video compression for browser + Node.js. OffscreenCanvas → FFmpeg Wasm → native ffmpeg. AVIF, WebP, Opus, H.264.
 
 ## ES6
 


### PR DESCRIPTION
## What

Adds [omni-compress](https://github.com/dharanish-v/omni-compress) to the **Image Processing** section.

## Why it fits

- Universal image, audio & video compression library for both **browser and Node.js**
- Browser path: OffscreenCanvas (fast) → @jsquash/avif (AVIF) → FFmpeg Wasm (heavy)
- Node.js path: native ffmpeg binary
- Web Workers, TypeScript, ESM + CJS, MIT license
- Fills a gap that no other entry in this list covers: isomorphic media compression with AVIF + audio + video

## Package

- npm: https://www.npmjs.com/package/omni-compress
- GitHub: https://github.com/dharanish-v/omni-compress