### PR TITLE
Add fallow to QA Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [JS-Beautifier](https://github.com/beautify-web/js-beautify) - Npm cli and library to format JS code.
 * [husky](https://github.com/typicode/husky) - Prevents bad git commit, git push and more.
 * [Rev-dep](https://github.com/jayu/rev-dep) - Trace imports, identify circular dependencies, find unused code, clean node modules — all from a blazing-fast CLI.
+* [fallow](https://github.com/fallow-rs/fallow) - Finds dead code, duplication, circular dependencies, and complexity hotspots in JavaScript and TypeScript projects.
 
 ## MVC Frameworks and Libraries
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

Adds fallow to QA Tools. fallow statically analyzes JavaScript and TypeScript projects for unused files, exports, and dependencies, plus duplication, circular dependencies, and complexity hotspots. Actively maintained, 380+ GitHub stars, 5 contributors, MIT licensed.