### PR TITLE
Add dxcharts-lite to Data Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [metrics-graphics](https://github.com/mozilla/metrics-graphics) - A library optimized for concise, principled data graphics and layouts.
 * [three.js](https://github.com/mrdoob/three.js) - JavaScript 3D library.
 * [Chart.js](https://github.com/chartjs/Chart.js) - Simple HTML5 Charts using the &lt;canvas&gt; tag.
+* [dxcharts-lite](https://github.com/devexperts/dxcharts-lite) - Flexible financial charts based on HTML5 canvas.
 * [paper.js](https://github.com/paperjs/paper.js) - The Swiss Army Knife of Vector Graphics Scripting – Scriptographer ported to JavaScript and the browser, using HTML5 Canvas.
 * [fabric.js](https://github.com/kangax/fabric.js) - JavaScript Canvas Library, SVG-to-Canvas (& canvas-to-SVG) Parser.
 * [peity](https://github.com/benpickles/peity) - Progressive <svg> bar, line and pie charts.


### PR DESCRIPTION
Hi! I would like to submit dxcharts-lite for the Data Visualization section.

**What is it?**
[dxcharts-lite](https://github.com/devexperts/dxcharts-lite) is an open-source, lightweight financial charting library built on HTML5 canvas. It is designed specifically for rendering high-performance, interactive stock, forex, and crypto charts.

**Why does it belong here?**
It provides a highly flexible API for developers building trading platforms or financial dashboards, handling complex data visualizations and custom indicators smoothly.

I've reviewed the contributing guidelines and ensured the formatting matches the surrounding entries. Thank you for taking a look!