### PR TITLE
Add Uni-CLI to Generative AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 ## Generative AI
 
 * [KaibanJS](https://github.com/kaiban-ai/KaibanJS) - KaibanJS is an open-source framework browser-compatibility of orchestration of multi-agent ai systems using a Kanban-inspired architecture.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing TypeScript CLI exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents via 920 declarative YAML adapters and structured error envelopes; ships an optional MCP server.
 
 ## Misc
 


### PR DESCRIPTION
## What
Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to **Generative AI**.

## What it does
Self-repairing CLI catalog that exposes **237+ websites, desktop apps, and external CLIs** as deterministic commands for AI agents. 920 declarative YAML adapters + 216 TS adapters surface 3,319 commands. Ships an optional MCP server (stdio + Streamable HTTP). Median ~80 tokens per call.

The differentiator is **self-repair**: every error is a structured envelope (`code`, `adapter_path`, `step`, `suggestion`, `retryable`, `alternatives`). When a target site rotates a selector or auth, the calling agent edits the YAML at `adapter_path` and retries — no maintainer in the loop.

## Format
- `* [PACKAGE](LINK) - DESCRIPTION.` per CONTRIBUTING.
- Period at end. No trailing whitespace. Spelling/grammar checked.
- One PR for one suggestion.

## Project signals (tested + documented)
- Apache-2.0, TypeScript strict, Node ≥ 20.
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli) — actively published.
- 170 test files, full `npm run verify` pipeline (typecheck + lint + tests).
- Docs: https://olo-dot-io.github.io/Uni-CLI/
- Latest release: v0.218.0 (2026-05-05).