### PR TITLE
Add Bilig

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 
 ## Spreadsheet
 
+* [Bilig](https://github.com/proompteng/bilig) - Headless TypeScript spreadsheet engine for Node.js services and agents.
 * [HANDSONTABLE](https://github.com/handsontable/handsontable) - Handsontable is a JavaScript/HTML5 Spreadsheet Library for Developers
 * [Frappe Datatable](https://github.com/frappe/datatable) - Frappe DataTable is a simple, modern and interactive datatable library for displaying tabular data.
 * [Luckysheet](https://github.com/mengshukeji/Luckysheet) - Luckysheet is an online spreadsheet like excel that is powerful, simple to configure, and completely open source.


### PR DESCRIPTION
Adds Bilig to the Spreadsheet section.

Bilig is a documented MIT TypeScript spreadsheet engine for Node.js services and agent workflows, with runnable examples and public npm package metadata:

- Repository: https://github.com/proompteng/bilig
- Package: https://www.npmjs.com/package/@bilig/headless
- Docs: https://proompteng.github.io/bilig/

This is an individual suggestion and follows the existing `[PACKAGE](LINK) - DESCRIPTION.` format.