### PR TITLE
Add dakera-js: JavaScript SDK for self-hosted agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Synapses](https://github.com/mrdimosthenis/Synapses) - Lightweight cross-platform Neural Network library.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native JavaScript code with zero dependencies.
 * [JS-PyTorch](https://github.com/eduardoleao052/js-pytorch) - GPU accelerated PyTorch in JavaScript.
+* [dakera-js](https://github.com/dakera-ai/dakera-js) - JavaScript SDK for Dakera, a self-hosted MCP agent memory server with decay-weighted recall and HNSW vector search.
 
 ## Browser Detection
 


### PR DESCRIPTION
## What this adds

[dakera-js](https://github.com/dakera-ai/dakera-js) is the JavaScript SDK for Dakera, a self-hosted MCP agent memory server with decay-weighted recall and HNSW vector search.

Added under **Machine Learning** section alongside other JS ML/AI libraries.

## Checklist

- Matches existing entry format (`* [name](url) - description`)
- No existing Dakera entry in this list
- Link points to the correct upstream repo