### PR TITLE
Add Vitest and ofetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Cypress](https://www.cypress.io/) - Complete end-to-end testing framework for anything that runs in a browser and beyond.
 * [WebdriverI/O](https://webdriver.io/) - Next-gen browser and mobile automation test framework for Node.js
 * [Suites](https://suites.dev) - A unit-testing framework for backends working with inversion of control and dependency injection
+* [Vitest](https://github.com/vitest-dev/vitest) - A blazing fast Vite-native unit test framework with out-of-box ESM, TypeScript and JSX support.
 
 ### Assertion
 
@@ -1083,6 +1084,7 @@ https://listjs.com
 * [Array Explorer](https://github.com/sdras/array-explorer) and [Object Explorer](https://objectexplorer.netlify.app/) - Resources to help figure out what native JavaScript method would be best to use at any given time.
 * [Clipboard.js](https://clipboardjs.com/) - "Copy to clipboard" without Flash or use of Frameworks.
 * [ky](https://github.com/sindresorhus/ky) - Tiny and elegant HTTP client based on the browser Fetch API.
+* [ofetch](https://github.com/unjs/ofetch) - A better fetch API that works uniformly in Node.js, browsers, and workers.
 * [Fcal](https://github.com/5anthosh/fcal) -  Math expression evaluator.
 * [emoji-button](https://github.com/joeattardi/emoji-button) - Vanilla JavaScript emoji picker component.
 * [iooxa](https://github.com/iooxa/article) - Components for interactive scientific writing, reactive documents and explorable explanations.


### PR DESCRIPTION
## Description

Added two popular JavaScript tools that were missing from the collection:

### Testing Frameworks:
- **[Vitest](https://github.com/vitest-dev/vitest)** - A blazing fast Vite-native unit test framework. Features out-of-box ESM, TypeScript, and JSX support. Widely adopted as the modern alternative to Jest for Vite-based projects. 14k+ GitHub stars.

### Misc (API):
- **[ofetch](https://github.com/unjs/ofetch)** - A better fetch API by the UnJS team that works uniformly in Node.js, browsers, and workers. Supports JSON parsing, retries, timeouts, and interceptors out of the box. Part of the Nuxt/UnJS ecosystem.

### Why:
- **Vitest** has become one of the most popular testing frameworks in the JS ecosystem, especially for Vite-based projects. It was missing from the Testing Frameworks section.
- **ofetch** is the modern, universal alternative to both `fetch` and `axios`, from the creators of Nuxt.js. It fills a gap in the HTTP client landscape.

## Checklist
- [x] Format matches existing entries
- [x] Tools are actively maintained and open source
- [x] Not duplicates of existing entries