### PR TITLE
Add coverage-gate to the Coverage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [istanbul](https://github.com/gotwarlost/istanbul) - Yet another JS code coverage tool.
 * [blanket](https://github.com/alex-seville/blanket) - A simple code coverage library for JavaScript. Designed to be easy to install and use, for both browser and nodejs.
 * [JSCover](https://github.com/tntim96/JSCover) - JSCover is a tool that measures code coverage for JavaScript programs.
+* [coverage-gate](https://github.com/task-bounty/coverage-gate) - Zero-dependency CLI and GitHub Action that reads your LCOV or json-summary report, shows the gap to a coverage target, and fails CI below it.
 
 ### Runner
 


### PR DESCRIPTION
Adds coverage-gate to the Testing Frameworks > Coverage section, alongside istanbul, blanket, and JSCover.

It is a zero-dependency CLI and GitHub Action that reads the coverage report your test run already produced (LCOV or Istanbul json-summary), reports current line coverage, the gap to a target (default 80%), and the lowest-covered files, and fails CI when below target. Works with jest, vitest, nyc, and c8. MIT, tested, documented.

Disclosure: I maintain this tool (it is part of TaskBounty). It is free, open source, and works fully standalone with no account or network calls.

Checklist:
- Individual PR for a single suggestion
- Format `[name](link) - description.` with a trailing period
- Tested (node:test) and documented (README)
- Not a duplicate