### PR TITLE
Add liter-llm to Generative AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 ## Generative AI
 
 * [KaibanJS](https://github.com/kaiban-ai/KaibanJS) - KaibanJS is an open-source framework browser-compatibility of orchestration of multi-agent ai systems using a Kanban-inspired architecture.
+* [liter-llm](https://github.com/xberg-io/liter-llm) - Universal LLM API client for 142+ providers with a unified interface and streaming, via a JavaScript/TypeScript binding over a Rust core.
 
 ## Misc
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub. — 251★

---

**liter-llm** is a universal LLM API client that exposes one unified interface across 142+ providers, with streaming support. The JavaScript/TypeScript package is a binding over a Rust core, published on npm as `@xberg-io/liter-llm`.

It belongs in Generative AI alongside KaibanJS: where KaibanJS orchestrates multi-agent systems, liter-llm is the provider-abstraction layer underneath — it lets JS/TS code target many model providers without rewriting call sites per vendor SDK. MIT licensed and actively maintained.
