### PR TITLE
Add interface-forge to Testing Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Yup](https://github.com/jquense/yup) - JavaScript schema builder and validator.
 
 ## Testing Frameworks
+* [interface-forge](https://github.com/Goldziher/interface-forge) - Graceful, type-safe mock-data generation for TypeScript, with factories and Faker integration.
 
 ### Frameworks
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained. — first released 2021, still actively maintained
- [ ] This resource is popular enough and has at least a few hundred stars on GitHub. — 102★, so short of a few hundred. Flagging it honestly rather than checking the box; happy for you to close if that's the bar.

---

**interface-forge** is type-safe mock and fixture data generation for TypeScript, built on factories with Faker integration.

On the placement note: it was previously dropped directly under `## Testing Frameworks` with no subsection, which was wrong. It's now at the end of `### Assertion`, which is where the existing stubbing and mocking entries live (Sinon.JS, proxyquire, Pocket Mocker). Happy to move it elsewhere if you'd rather it sat somewhere else.
