### PR TITLE
Add altor-vec to Full Text Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [lunr](https://github.com/olivernn/lunr.js) - Library for use in the browser and It indexes JSON documents and provides a simple search interface for retrieving documents that best match text queries.
 * [flexsearch](https://github.com/nextapps-de/flexsearch) - It is a Next-Generation full text search library for Browser and Node.js.
 * [Elasticlunr](https://github.com/weixsong/elasticlunr.js) - This library is based on lunr.js, but more flexible and customized.
+* [altor-vec](https://github.com/altor-lab/altor-vec) - In-browser HNSW vector search compiled to 54KB WASM. Sub-millisecond semantic search for JavaScript with no server or API keys required.
   
 ## ORM
 


### PR DESCRIPTION
## altor-vec

[altor-vec](https://github.com/altor-lab/altor-vec) is an in-browser HNSW vector search engine compiled to 54KB of WebAssembly.

**Why it belongs in Full Text Search alongside lunr / flexsearch / Elasticlunr:**
- Runs entirely in the browser with no server required
- Sub-millisecond search (0.6ms p95 for 10K vectors in Chrome)
- Semantic/vector search rather than keyword matching: 'cancel subscription' finds 'end your plan'
- npm install altor-vec, MIT licensed
- Docs: https://altorlab.dev

It fills a gap in this section: lunr and flexsearch are keyword-based; altor-vec is the browser-native option for semantic vector search.