### PR TITLE
Add hushvert to Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [diff2html](https://github.com/rtfpessoa/diff2html) - Git diff output parser and pretty HTML generator.
 * [jsPDF](https://github.com/MrRio/jsPDF) - JavaScript PDF generation.
 * [PDF.js](https://github.com/mozilla/pdf.js) - PDF Reader in JavaScript.
+* [hushvert](https://github.com/hushvert/engine) - Client-side file conversion in the browser via WebAssembly: images (HEIC, JPEG XL, TIFF), PDFs, archives, audio and small video, with no uploads.
 
 ## Functional Programming
 *Functional programming libraries to extend JavaScript’s capabilities.*


### PR DESCRIPTION
Adds **hushvert** to the `Files` section.

[@hushvert/engine](https://github.com/hushvert/engine) (MIT) is a client-side file-conversion library that runs in the browser via WebAssembly - images (HEIC, JPEG XL, TIFF), PDFs, archives, audio and small video - with no uploads. One suggestion in this PR; the entry matches the section's format and links the repo.

Disclosure: I maintain it.
