### PR TITLE
Add Markstream to Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 ## Streaming
 
 * [Tailor](https://github.com/zalando/tailor) - Streaming layout service for front-end microservices, inspired by Facebook's BigPipe.
+* [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for AI chat interfaces across Vue, React, Svelte and Angular.
 
 ## Vision Detection
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

---

Markstream is a documented, MIT-licensed JavaScript/TypeScript library for rendering incomplete Markdown while AI-chat responses stream. It supports Vue, React, Svelte, and Angular. I maintain the project.