### PR TITLE
Add @pionjs/pion

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [Million](https://github.com/aidenybai/million) - <1kb compiler-focused virtual DOM. It's fast!
 * [Whatsup](https://github.com/whatsup/whatsup) - A frontend framework for chillout-mode development 🥤. JSX components on generators, fast mobx-like state management and exclusive cssx style system.
 * [Remult](https://github.com/remult/remult) - A CRUD framework for full-stack TypeScript.
+* [pion](https://github.com/pionjs/pion) - React Hooks API for standard web components with lit-html.
 
 ## Node-Powered CMS Frameworks
 


### PR DESCRIPTION
Adds [pion](https://github.com/pionjs/pion) — React's Hooks API for standard web components with lit-html.

Fork of [haunted](https://github.com/matthewp/haunted), actively maintained with full TypeScript support. Docs: https://pionjs.com · npm: https://npm.im/@pionjs/pion