### PR TITLE
Add Blok to Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [popline](https://github.com/kenshin54/popline) - Popline is an HTML5 Rich-Text-Editor Toolbar.
 * [Summernote](https://github.com/summernote/summernote) - Super simple WYSIWYG editor.
 * [Everright-formEditor](https://github.com/Liberty-liu/Everright-formEditor) - A visual drag-and-drop low-code form editor
+* [Blok](https://github.com/JackUait/blok) - Headless block-based rich text editor that outputs JSON instead of HTML.
 
 ## Documentation
 


### PR DESCRIPTION
Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [ ] This resource is popular enough and has at least a few hundred stars on GitHub.

---

Adding [Blok](https://github.com/JackUait/blok) to Editors.

Blok is a headless, block-based rich text editor. Unlike the other entries in this section it does not produce an HTML blob — content is stored as typed JSON blocks, so it can be diffed, queried, and rendered server-side without a DOM. It ships block tools (paragraph, heading, list, table, code, columns, embeds), inline formatting, and first-party React, Vue and Angular adapters. Apache-2.0, no paid tier.

**On the last checkbox — I have deliberately left it unchecked.** Blok is at 28 stars, well under your "few hundred" bar. It is genuinely maintained (public since November 2025, released continuously, currently 1.3.0 on npm across four packages) but it does not meet the popularity criterion as written, and I would rather say so than quietly tick the box. Please close this if the bar is firm — no hard feelings, and I'll resubmit when the numbers are there.