### PR TITLE
Add Sanwo to SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Square Node.js SDK](https://github.com/square/connect-nodejs-sdk/) - JavaScript client library for payments and other Square APIs.
 * [OpenAI SDK](https://github.com/openai/openai-node) - Official JavaScript / TypeScript library for the OpenAI API.
 * [Stripe Node.js SDK](https://github.com/stripe/stripe-node) - Stripe Node.js SDK lets you integrate payments, subscriptions, and billing into your JavaScript/TypeScript apps.
-* [Sanwo](https://github.com/Sanwohq/core) - Universal payment SDK. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. SDKs for React, Vue, Svelte, and vanilla JS.
+* [Sanwo](https://github.com/Sanwohq) - Universal payment SDK. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. SDKs for React, Vue, Svelte, and vanilla JS.
 
 ## Full Text Search
 

--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Square Node.js SDK](https://github.com/square/connect-nodejs-sdk/) - JavaScript client library for payments and other Square APIs.
 * [OpenAI SDK](https://github.com/openai/openai-node) - Official JavaScript / TypeScript library for the OpenAI API.
 * [Stripe Node.js SDK](https://github.com/stripe/stripe-node) - Stripe Node.js SDK lets you integrate payments, subscriptions, and billing into your JavaScript/TypeScript apps.
+* [Sanwo](https://github.com/Sanwohq/core) - Universal payment SDK. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. SDKs for React, Vue, Svelte, and vanilla JS.
 
 ## Full Text Search
 


### PR DESCRIPTION
Adds [Sanwo](https://github.com/Sanwohq/core) to the SDK section alongside Square and Stripe.

Sanwo is an open-source universal payment SDK. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. Ships framework-specific SDKs for React, Vue, Svelte, and vanilla JS.

- **npm:** https://www.npmjs.com/org/sanwohq
- **Docs:** https://docs.sanwo.dev
- **License:** Apache-2.0