### PR TITLE
Add microcharts to Data Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ A collection of awesome browser-side [JavaScript](https://developer.mozilla.org/
 * [svg.js](https://github.com/wout/svg.js) - A lightweight library for manipulating and animating SVG.
 * [heatmap.js](https://github.com/pa7/heatmap.js) - JavaScript Library for HTML5 canvas based heatmaps.
 * [jquery.sparkline](https://github.com/gwatts/jquery.sparkline) - A plugin for the jQuery JavaScript library to generate small sparkline charts directly in the browser.
+* [microcharts](https://github.com/ganapativs/microcharts) - Word-sized React charts for inline text, table cells, and KPI cards. SVG, zero dependencies, accessible by default.
 * [trianglify](https://github.com/qrohlf/trianglify) - Low poly style background generator with d3.js.
 * [d3-cloud](https://github.com/jasondavies/d3-cloud) - Create word clouds in JavaScript.
 * [d4](https://github.com/heavysixer/d4) - A friendly reusable charts DSL for D3.


### PR DESCRIPTION
Adds microcharts to **Data Visualization**, placed next to `jquery.sparkline` since it covers the same territory.

```
* [microcharts](https://github.com/ganapativs/microcharts) - Word-sized React charts for inline text, table cells, and KPI cards. SVG, zero dependencies, accessible by default.
```

Disclosure: I'm the author.

The section's existing entries are full-canvas charting libraries; the one closest to this niche, `jquery.sparkline`, hasn't been updated in years. microcharts covers the same "chart small enough to sit inside a line of text" case with a maintained, dependency-free implementation: 106 chart types, MIT, ~1–4 kB gzip per chart, `role="img"` with a generated natural-language summary on every chart, and static entries that render server-side with no client JS.

Guidelines checklist:

- [x] Searched previous suggestions — no existing entry
- [x] Tested and documented ([docs](https://microcharts.dev/docs))
- [x] Individual PR for this one suggestion
- [x] Format `[PACKAGE](LINK) - DESCRIPTION.`
- [x] Description short and descriptive, ends with a full stop
- [x] Spelling/grammar checked, no trailing whitespace

Note it is React-specific, which I flagged in the description. The list already includes React-scoped entries (react, preact, Enzyme, react-testing-library, Keo), so I assumed that's acceptable — happy to move or drop it if you'd rather keep this section framework-agnostic.
