### PR TITLE
Add saas-startup to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
  * [this-is-responsive](https://github.com/bradfrost/this-is-responsive) - This Is Responsive.
  * [npm run-scripts](https://gist.github.com/addyosmani/9f10c555e32a8d06ddb0) Task automation with NPM run-scripts.
  * [Wasp](https://github.com/wasp-lang/wasp) Wasp is a declarative domain-specific language for developing, building, and deploying modern Javascript full-stack web apps with less code.
+ * [saas-startup](https://github.com/mailkite/saas-startup) - Production-ready Next.js 15 SaaS starter with self-contained auth (Google/GitHub OAuth + email/password, no auth vendor), Stripe subscriptions, teams, Postgres/Drizzle, and a dark-first UI.
 
 ## Images
 


### PR DESCRIPTION
Hi 👋

This PR adds **[mailkite/saas-startup](https://github.com/mailkite/saas-startup)** to the **Boilerplates** section — a production-ready **Next.js 15** SaaS starter.

**What it is:** a full-stack JavaScript SaaS boilerplate featuring self-contained auth (Google/GitHub OAuth + email/password — runs in your own app, no Clerk/Auth0/Supabase account), Stripe subscriptions, teams, PostgreSQL + Drizzle ORM, and a dark-first shadcn/ui interface. MIT-licensed, with a live demo at https://saas-startup.mailkite.dev.

**Why it fits the Boilerplates section:** it sits naturally alongside **Wasp** as a full-stack JS application starter (the section already mixes front-end HTML templates and full-stack app frameworks).

Follows the contributing format (`[PACKAGE](LINK) - DESCRIPTION.`), one suggestion per PR, ends with a full stop. Happy to adjust the wording if you'd like it shorter.

Thanks for maintaining this list!