### PR TITLE
Add AgentsKit to Generative AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 ## Generative AI
 
 * [KaibanJS](https://github.com/kaiban-ai/KaibanJS) - KaibanJS is an open-source framework browser-compatibility of orchestration of multi-agent ai systems using a Kanban-inspired architecture.
+* [AgentsKit](https://github.com/AgentsKit-io/agentskit) - A modular TypeScript toolkit for building provider-independent AI agents with a tiny core and independently installable runtime, memory, RAG, tools, sandbox, observability, and evaluation packages.
 
 ## Misc
 


### PR DESCRIPTION
## What this adds

Adds AgentsKit to the Generative AI section as a modular TypeScript toolkit for building provider-independent AI agents.

## Validation

- confirmed the repository is public, MIT-licensed, active, tested, and documented;
- searched the current list plus open and closed issues and pull requests for an existing AgentsKit entry;
- used the documented one-line package format and placed the entry at the bottom of the matching section;
- limited the change to one line in `README.md`.

I maintain AgentsKit and will respond to review feedback.
