### PR TITLE
Add Optik Sol to logging tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [console.log-wrapper](https://github.com/patik/console.log-wrapper) - Log to the console in any browser with clarity.
 * [loglevel](https://github.com/pimterry/loglevel) - Minimal lightweight logging for JavaScript, adding reliable log level methods to wrap any available console.log methods.
 * [minilog](http://mixu.net/minilog/) – Lightweight client & server-side logging with Stream-API backends.
+* [Optik Sol](https://github.com/Moresyl/optik-sol) - Mobile-first in-page developer console for debugging real devices and WebViews.
 * [storyboard](http://guigrpa.github.io/storyboard/) - Universal logging library + Chrome extension; it lets you see all client and server tasks triggered by a user action in a single place.
 * [LogTape](https://logtape.org/) - Simple logging library with zero dependencies for Deno, Node.js, Bun, browsers, and edge functions.
 


### PR DESCRIPTION
Optik Sol is a mobile-first in-page developer console for debugging real devices and WebViews.