### PR TITLE
Add scroll-frame-sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [stroll](https://github.com/hakimel/stroll.js) - A collection of CSS List scroll effects bind to dom through javascript.
 * [locomotive-scroll](https://github.com/locomotivemtl/locomotive-scroll) - Detects the elements in viewport and smooth scrolling with parallax.
 * [elevator.js](https://github.com/tholman/elevator.js) - Finally, a "back to top" button that behaves like a real elevator.
+* [scroll-frame-sequence](https://github.com/tangyistudio/scroll-frame-sequence) - Scroll-driven image sequence player with hold loops, portrait pan and three-layer loading. Zero dependencies.
 
 ## Menu
 


### PR DESCRIPTION
A zero-dependency scroll-driven image sequence player — scroll position selects
the frame rather than a clock. Includes hold loops, a portrait pan schedule for
9:16 viewports, and the Python pipeline that produces the frames.

Live demo: https://demo.tangyi.mx
npm: https://www.npmjs.com/package/scroll-frame-sequence

MIT, TypeScript types included, tested, CI on Node 18/20/22.

Checked the guidelines: searched for duplicates, one PR for one suggestion,
format matches, description ends with a period.