### PR TITLE
Add xexcel to Spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [Luckysheet](https://github.com/mengshukeji/Luckysheet) - Luckysheet is an online spreadsheet like excel that is powerful, simple to configure, and completely open source.
  * [Jspreadsheet CE](https://github.com/jspreadsheet/ce) - Jspreadsheet is a lightweight vanilla javascript plugin to create amazing web-based interactive tables and spreadsheets compatible with other spreadsheet software.
  * [RevoGrid](https://github.com/revolist/revogrid) - RevoGrid is a fast, responsive excel like data grid library for modern web applications.
+* [xexcel](https://github.com/ximing/xexcel) - Embeddable Excel-style spreadsheet with a State/Transaction/Plugin kernel, formula engine, and xlsx/CSV I/O.
 
 ## Editors
 


### PR DESCRIPTION
Add [xexcel](https://github.com/ximing/xexcel) under Spreadsheet.

MIT-licensed embeddable Excel-style spreadsheet (State/Transaction/Plugin), formula engine, xlsx/CSV I/O, React embed.

- Demo: https://ximing.github.io/xexcel/