### PR TITLE
Add speedy-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ There're also some great commercial libraries, like [amchart](https://www.amchar
 * [crossroads](https://github.com/millermedeiros/crossroads.js) - JavaScript Routes.
 * [davis.js](https://github.com/olivernn/davis.js) - RESTful degradable JavaScript routing using pushState.
 * [navaid](https://github.com/lukeed/navaid) - A navigation aid (aka, router) for the browser in 850 bytes~!
+* [speedy-router](https://github.com/anonrig/router) - The TanStack Router API rebuilt for faster navigations and SSR.
 
 ## Security
 


### PR DESCRIPTION
Adds [speedy-router](https://github.com/anonrig/router) to **Routing**.

Checklist:

- [x] I've read and understood [Contributing Guidelines](CONTRIBUTING.md).
- [x] I've added the new resource at the end of its section.
- [x] This resource is out there for a while, and actively maintained.
- [x] This resource is popular enough and has at least a few hundred stars on GitHub.

[speedy-router](https://github.com/anonrig/router) is a from-scratch React 19.2 router that keeps the TanStack Router public API and rebuilds the hot path for faster navigations and streaming SSR.